### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,31 @@
 setting.py
+
+# Created by https://www.gitignore.io/api/java
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+
+# End of https://www.gitignore.io/api/java


### PR DESCRIPTION
¿Qué ha cambiado?
Agregamos al gitignore soporte para java
- [ ] Frontend
- [ ] Backend
- [x] Configuracion del server

# ¿Cómo puedo probar los cambios?
Por ejemplo los archivos y la carpeta node_modules ya no se suben al repo, ver el archivo .gitignore completo
